### PR TITLE
Shioichi bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IntelliJ project files
+.idea
+out
+gen
+

--- a/010pixel_tmplt_list_metabox.php
+++ b/010pixel_tmplt_list_metabox.php
@@ -309,8 +309,19 @@
 			if ( in_array ( $postType, $PostTypesWithTemplateAllwed) ) {
 				
 				$templateFile = get_post_meta($postId, $postType . '_template', true);
-				
-				$template = locate_template( $templateFile, false );
+
+				if ( "default" == $templateFile ) {
+
+					$templates[] = "single-{$postType}.php";
+					$templates[] = "single.php";
+
+					$template = locate_template( $templates, false );
+
+				} else {
+
+					$template = locate_template( $templateFile, false );
+
+				}
 				
 				return $template;
 			}


### PR DESCRIPTION
投稿やカスタム投稿タイプでカスタムテンプレートを適用していない場合、単一記事ページなら「single.php」や「single-{post_type}.php」が読み込まれるはずが「index.php」を読み込むコードになっていたので修正しました。
